### PR TITLE
[FIX] BusReviewEntity에서 station_id 삭제

### DIFF
--- a/server/src/main/java/com/talkka/server/review/dao/BusReviewEntity.java
+++ b/server/src/main/java/com/talkka/server/review/dao/BusReviewEntity.java
@@ -53,9 +53,6 @@ public class BusReviewEntity {
 	@JoinColumn(name = "route_id")
 	private BusRouteEntity route;
 
-	@Column(name = "station_id", nullable = false, updatable = false)
-	private Long stationId;
-
 	@Column(name = "content")
 	private String content;
 


### PR DESCRIPTION
- #22 에서 테이블 분할 시 BusReviewEntity에서 station_id 삭제를 누락하여 삭제처리하였습니다!