### PR TITLE
[FEAT] 북마크 컨트롤러 구현 및 TransportType Enum 리팩토링

### DIFF
--- a/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
@@ -33,7 +33,7 @@ public class BookmarkController {
 	// 본인이 작성한 북마크 리스트만 조회
 	@GetMapping("")
 	public ResponseEntity<?> getBookmarkList(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo) {
-		List<BookmarkRespDto> bookmarks = bookmarkService.getByUserId(oAuth2UserInfo.getUserId());
+		List<BookmarkRespDto> bookmarks = bookmarkService.getBookmarkByUserId(oAuth2UserInfo.getUserId());
 		return ResponseEntity.ok(bookmarks);
 	}
 
@@ -42,7 +42,7 @@ public class BookmarkController {
 		@PathVariable Long bookmarkId) {
 		ResponseEntity<?> response;
 		try {
-			BookmarkRespDto bookmark = bookmarkService.getByBookmarkId(oAuth2UserInfo.getUserId(), bookmarkId);
+			BookmarkRespDto bookmark = bookmarkService.getBookmarkById(oAuth2UserInfo.getUserId(), bookmarkId);
 			response = ResponseEntity.ok(bookmark);
 		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException exception) {
 			response = ResponseEntity.badRequest().body(exception.getMessage());

--- a/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
@@ -17,6 +17,7 @@ import com.talkka.server.bookmark.dto.BookmarkReqDto;
 import com.talkka.server.bookmark.dto.BookmarkRespDto;
 import com.talkka.server.bookmark.exception.BookmarkNotFoundException;
 import com.talkka.server.bookmark.exception.BookmarkUserNotFoundException;
+import com.talkka.server.bookmark.exception.enums.InvalidTransportTypeEnumException;
 import com.talkka.server.bookmark.service.BookmarkService;
 import com.talkka.server.oauth.domain.OAuth2UserInfo;
 import com.talkka.server.review.exception.ContentAccessException;
@@ -59,12 +60,13 @@ public class BookmarkController {
 		try {
 			BookmarkRespDto bookmark = bookmarkService.createBookmark(bookmarkReqDto, oAuth2UserInfo.getUserId());
 			return ResponseEntity.ok(bookmark);
-		} catch (BookmarkUserNotFoundException exception) {
+		} catch (BookmarkUserNotFoundException | InvalidTransportTypeEnumException exception) {
 			response = ResponseEntity.badRequest().body(exception.getMessage());
 		}
 		return response;
 	}
 
+	@SuppressWarnings("checkstyle:OperatorWrap")
 	@PutMapping("{bookmarkId}")
 	public ResponseEntity<?> updateBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
 		BookmarkReqDto bookmarkReqDto, @PathVariable Long bookmarkId) {
@@ -73,7 +75,8 @@ public class BookmarkController {
 			BookmarkRespDto bookmark = bookmarkService.updateBookmark(bookmarkReqDto, oAuth2UserInfo.getUserId(),
 				bookmarkId);
 			response = ResponseEntity.ok(bookmark);
-		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException exception) {
+		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException |
+				 InvalidTransportTypeEnumException exception) {
 			response = ResponseEntity.badRequest().body(exception.getMessage());
 		} catch (ContentAccessException exception) {
 			response = ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.getMessage());

--- a/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
@@ -1,0 +1,98 @@
+package com.talkka.server.bookmark.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.talkka.server.bookmark.dto.BookmarkReqDto;
+import com.talkka.server.bookmark.dto.BookmarkRespDto;
+import com.talkka.server.bookmark.exception.BookmarkNotFoundException;
+import com.talkka.server.bookmark.exception.BookmarkUserNotFoundException;
+import com.talkka.server.bookmark.service.BookmarkService;
+import com.talkka.server.oauth.domain.OAuth2UserInfo;
+import com.talkka.server.review.exception.ContentAccessException;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bookmark")
+public class BookmarkController {
+	private final BookmarkService bookmarkService;
+
+	// 본인이 작성한 북마크 리스트만 조회
+	// 리스트로 반환되는것을 명확하게 드러내기 위해 /bookmark/list 로 설정
+	@GetMapping("/list")
+	public ResponseEntity<?> getBookmarkList(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo) {
+		List<BookmarkRespDto> bookmarks = bookmarkService.getByUserId(oAuth2UserInfo.getUserId());
+		return ResponseEntity.ok(bookmarks);
+	}
+
+	@GetMapping("/{bookmarkId}")
+	public ResponseEntity<?> getBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
+		@PathVariable Long bookmarkId) {
+		ResponseEntity<?> response;
+		try {
+			BookmarkRespDto bookmark = bookmarkService.getByBookmarkId(oAuth2UserInfo.getUserId(), bookmarkId);
+			response = ResponseEntity.ok(bookmark);
+		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		} catch (ContentAccessException exception) {
+			response = ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.getMessage());
+		}
+		return response;
+	}
+
+	@PostMapping("")
+	public ResponseEntity<?> createBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
+		BookmarkReqDto bookmarkReqDto) {
+		ResponseEntity<?> response;
+		try {
+			BookmarkRespDto bookmark = bookmarkService.createBookmark(bookmarkReqDto, oAuth2UserInfo.getUserId());
+			return ResponseEntity.ok(bookmark);
+		} catch (BookmarkUserNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		}
+		return response;
+	}
+
+	@PutMapping("{bookmarkId}")
+	public ResponseEntity<?> updateBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
+		BookmarkReqDto bookmarkReqDto, @PathVariable Long bookmarkId) {
+		ResponseEntity<?> response;
+		try {
+			BookmarkRespDto bookmark = bookmarkService.updateBookmark(bookmarkReqDto, oAuth2UserInfo.getUserId(),
+				bookmarkId);
+			response = ResponseEntity.ok(bookmark);
+		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		} catch (ContentAccessException exception) {
+			response = ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.getMessage());
+		}
+		return response;
+	}
+
+	@DeleteMapping("/{bookmarkId}")
+	public ResponseEntity<?> deleteBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
+		@PathVariable Long bookmarkId) {
+		ResponseEntity<?> response;
+		try {
+			bookmarkService.deleteBookmark(oAuth2UserInfo.getUserId(), bookmarkId);
+			response = ResponseEntity.ok().build();
+		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		} catch (ContentAccessException exception) {
+			response = ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.getMessage());
+		}
+		return response;
+	}
+}

--- a/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/com/talkka/server/bookmark/controller/BookmarkController.java
@@ -31,8 +31,7 @@ public class BookmarkController {
 	private final BookmarkService bookmarkService;
 
 	// 본인이 작성한 북마크 리스트만 조회
-	// 리스트로 반환되는것을 명확하게 드러내기 위해 /bookmark/list 로 설정
-	@GetMapping("/list")
+	@GetMapping("")
 	public ResponseEntity<?> getBookmarkList(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo) {
 		List<BookmarkRespDto> bookmarks = bookmarkService.getByUserId(oAuth2UserInfo.getUserId());
 		return ResponseEntity.ok(bookmarks);
@@ -66,7 +65,6 @@ public class BookmarkController {
 		return response;
 	}
 
-	@SuppressWarnings("checkstyle:OperatorWrap")
 	@PutMapping("{bookmarkId}")
 	public ResponseEntity<?> updateBookmark(@AuthenticationPrincipal OAuth2UserInfo oAuth2UserInfo,
 		BookmarkReqDto bookmarkReqDto, @PathVariable Long bookmarkId) {
@@ -75,8 +73,8 @@ public class BookmarkController {
 			BookmarkRespDto bookmark = bookmarkService.updateBookmark(bookmarkReqDto, oAuth2UserInfo.getUserId(),
 				bookmarkId);
 			response = ResponseEntity.ok(bookmark);
-		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException |
-				 InvalidTransportTypeEnumException exception) {
+		} catch (BookmarkNotFoundException | BookmarkUserNotFoundException
+				 | InvalidTransportTypeEnumException exception) {
 			response = ResponseEntity.badRequest().body(exception.getMessage());
 		} catch (ContentAccessException exception) {
 			response = ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.getMessage());

--- a/server/src/main/java/com/talkka/server/bookmark/dto/BookmarkDetailRespDto.java
+++ b/server/src/main/java/com/talkka/server/bookmark/dto/BookmarkDetailRespDto.java
@@ -1,11 +1,12 @@
 package com.talkka.server.bookmark.dto;
 
 import com.talkka.server.bookmark.dao.BookmarkDetailEntity;
+import com.talkka.server.bookmark.enums.TransportType;
 import com.talkka.server.subway.enums.Updown;
 
 public record BookmarkDetailRespDto(
 	Integer seq,
-	String type,
+	TransportType type,
 	Long subwayStationId,
 	Updown subwayUpdown,
 	Long busRouteStationId
@@ -13,7 +14,7 @@ public record BookmarkDetailRespDto(
 	public static BookmarkDetailRespDto of(BookmarkDetailEntity entity) {
 		return new BookmarkDetailRespDto(
 			entity.getSeq(),
-			entity.getType().getType(),
+			entity.getType(),
 			entity.getSubwayStationId(),
 			entity.getSubwayUpdown(),
 			entity.getBusRouteStationId()

--- a/server/src/main/java/com/talkka/server/bookmark/enums/TransportType.java
+++ b/server/src/main/java/com/talkka/server/bookmark/enums/TransportType.java
@@ -6,12 +6,9 @@ import lombok.Getter;
 
 @Getter
 public enum TransportType {
-	BUS("bus"), SUBWAY("subway");
+	BUS, SUBWAY;
 
-	private final String type;
-
-	TransportType(String type) {
-		this.type = type;
+	TransportType() {
 	}
 
 	public static TransportType valueOfEnumString(String enumValue) {

--- a/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
@@ -11,6 +11,7 @@ import com.talkka.server.bookmark.dto.BookmarkReqDto;
 import com.talkka.server.bookmark.dto.BookmarkRespDto;
 import com.talkka.server.bookmark.exception.BookmarkNotFoundException;
 import com.talkka.server.bookmark.exception.BookmarkUserNotFoundException;
+import com.talkka.server.bookmark.exception.enums.InvalidTransportTypeEnumException;
 import com.talkka.server.common.validator.ContentAccessValidator;
 import com.talkka.server.review.exception.ContentAccessException;
 import com.talkka.server.user.dao.UserEntity;
@@ -27,7 +28,9 @@ public class BookmarkService {
 	private final UserRepository userRepository;
 	private final ContentAccessValidator contentAccessValidator;
 
-	public BookmarkRespDto getByBookmarkId(Long userId, Long bookmarkId) throws BookmarkNotFoundException {
+	public BookmarkRespDto getByBookmarkId(Long userId, Long bookmarkId) throws
+		BookmarkNotFoundException,
+		BookmarkUserNotFoundException {
 		// 본인이 작성한 북마크만 조회 하도록 변경
 		UserEntity user = userRepository.findById(userId).orElseThrow(BookmarkUserNotFoundException::new);
 		BookmarkEntity bookmark = bookmarkRepository.findById(bookmarkId)
@@ -43,7 +46,8 @@ public class BookmarkService {
 	}
 
 	@Transactional
-	public BookmarkRespDto createBookmark(BookmarkReqDto dto, Long userId) throws BookmarkUserNotFoundException {
+	public BookmarkRespDto createBookmark(BookmarkReqDto dto, Long userId) throws BookmarkUserNotFoundException,
+		InvalidTransportTypeEnumException {
 		UserEntity user = userRepository.findById(userId).orElseThrow(BookmarkUserNotFoundException::new);
 		BookmarkEntity bookmark = dto.toEntity(user);
 		dto.details().stream()
@@ -56,6 +60,7 @@ public class BookmarkService {
 	public BookmarkRespDto updateBookmark(BookmarkReqDto dto, Long userId, Long bookmarkId) throws
 		BookmarkUserNotFoundException,
 		BookmarkNotFoundException,
+		InvalidTransportTypeEnumException,
 		ContentAccessException {
 
 		UserEntity user = userRepository.findById(userId).orElseThrow(BookmarkUserNotFoundException::new);

--- a/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
@@ -31,7 +31,7 @@ public class BookmarkService {
 	public BookmarkRespDto getBookmarkById(Long userId, Long bookmarkId) throws
 		BookmarkNotFoundException,
 		BookmarkUserNotFoundException,
-		InvalidTransportTypeEnumException {
+		ContentAccessException {
 		// 본인이 작성한 북마크만 조회 하도록 변경
 		UserEntity user = userRepository.findById(userId).orElseThrow(BookmarkUserNotFoundException::new);
 		BookmarkEntity bookmark = bookmarkRepository.findById(bookmarkId)

--- a/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/com/talkka/server/bookmark/service/BookmarkService.java
@@ -28,9 +28,10 @@ public class BookmarkService {
 	private final UserRepository userRepository;
 	private final ContentAccessValidator contentAccessValidator;
 
-	public BookmarkRespDto getByBookmarkId(Long userId, Long bookmarkId) throws
+	public BookmarkRespDto getBookmarkById(Long userId, Long bookmarkId) throws
 		BookmarkNotFoundException,
-		BookmarkUserNotFoundException {
+		BookmarkUserNotFoundException,
+		InvalidTransportTypeEnumException {
 		// 본인이 작성한 북마크만 조회 하도록 변경
 		UserEntity user = userRepository.findById(userId).orElseThrow(BookmarkUserNotFoundException::new);
 		BookmarkEntity bookmark = bookmarkRepository.findById(bookmarkId)
@@ -39,7 +40,7 @@ public class BookmarkService {
 		return BookmarkRespDto.of(bookmark);
 	}
 
-	public List<BookmarkRespDto> getByUserId(Long userId) {
+	public List<BookmarkRespDto> getBookmarkByUserId(Long userId) {
 		return bookmarkRepository.findByUserId(userId).stream()
 			.map(BookmarkRespDto::of)
 			.toList();


### PR DESCRIPTION
- 북마크 컨트롤러 구현
  - `GET` `/bookmark` : 본인이 작성한 북마크 리스트 반환
  - `GET` `/bookmark/{bookmarkId}` : bookmarkId로 북마크 조회
  - `POST` `/bookmark` : 북마크 생성
  - `DELETE` `/bookmark/{bookmarkId}` : bookmarkId로 북마크 삭제
  -  `PUT` `/bookmark/{bookmarkId}` : bookmarkId로 북마크 수정

- 북마크 서비스 수정
  - `getBookmarkById` 메소드에서 본인이 작성한 북마크만 조회하도록 수정 
  - 북마크 서비스 메소드 순서 변경 : get, create, update, delete 순서
  - 메소드 파라미터 순서 수정 : dto, userId, bookmarkId 순서
    - 받아야하는 파라미터가 늘어날수록 코드 가독성이 나빠질 수 있음 -> 추후 service단에서 사용할 dto를 분리하도록 리팩토링 고려

- TransportType Enum 리팩토링
  - `BookmarkRespDto` 에서 `TransportType`를 `String`이 아닌 `enum`으로 반환하도록 리팩토링
  - `TransportType`에서 `name` 필드가 불필요하다고 생각되어 삭제

close #84 