### PR TITLE
[REFACTOR]: 버스 도메인 리팩토링

### DIFF
--- a/server/src/main/java/com/talkka/server/bus/controller/BusRouteController.java
+++ b/server/src/main/java/com/talkka/server/bus/controller/BusRouteController.java
@@ -10,9 +10,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.talkka.server.bus.dto.BusRouteRespDto;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
 import com.talkka.server.bus.service.BusRouteService;
-import com.talkka.server.common.dto.ApiRespDto;
-import com.talkka.server.common.enums.StatusCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,8 +22,9 @@ public class BusRouteController {
 	private final BusRouteService busRouteService;
 
 	@GetMapping("")
-	public ResponseEntity<ApiRespDto<List<BusRouteRespDto>>> getRoutes(
-		@RequestParam(value = "search", required = false) String routeName) {
+	public ResponseEntity<List<BusRouteRespDto>> getRoutes(
+		@RequestParam(value = "search", required = false) String routeName
+	) {
 		List<BusRouteRespDto> routeList;
 
 		if (routeName != null) {
@@ -32,23 +32,18 @@ public class BusRouteController {
 		} else {
 			routeList = busRouteService.getRoutes();
 		}
-		return ResponseEntity.ok(
-			ApiRespDto.<List<BusRouteRespDto>>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(routeList)
-				.build()
-		);
+
+		return ResponseEntity.ok(routeList);
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiRespDto<BusRouteRespDto>> getRouteById(@PathVariable("id") Long routeId) {
-		return ResponseEntity.ok(
-			ApiRespDto.<BusRouteRespDto>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(busRouteService.getRouteById(routeId))
-				.build()
-		);
+	public ResponseEntity<?> getRouteById(@PathVariable("id") Long routeId) {
+		ResponseEntity<?> response;
+		try {
+			response = ResponseEntity.ok(busRouteService.getRouteById(routeId));
+		} catch (BusRouteNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		}
+		return response;
 	}
 }

--- a/server/src/main/java/com/talkka/server/bus/controller/BusRouteStationController.java
+++ b/server/src/main/java/com/talkka/server/bus/controller/BusRouteStationController.java
@@ -2,6 +2,7 @@ package com.talkka.server.bus.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,9 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.talkka.server.bus.dto.BusRouteStationRespDto;
+import com.talkka.server.bus.exception.BusRouteStationNotFoundException;
 import com.talkka.server.bus.service.BusRouteStationService;
-import com.talkka.server.common.dto.ApiRespDto;
-import com.talkka.server.common.enums.StatusCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,19 +23,19 @@ public class BusRouteStationController {
 	private final BusRouteStationService routeStationService;
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiRespDto<BusRouteStationRespDto>> getRouteStationById(
+	public ResponseEntity<?> getRouteStationById(
 		@PathVariable("id") Long routeStationId) {
-		return ResponseEntity.ok(
-			ApiRespDto.<BusRouteStationRespDto>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(routeStationService.getRouteStationById(routeStationId))
-				.build()
-		);
+		ResponseEntity<?> response;
+		try {
+			response = ResponseEntity.ok(routeStationService.getRouteStationById(routeStationId));
+		} catch (BusRouteStationNotFoundException exception) {
+			response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+		}
+		return response;
 	}
 
 	@GetMapping("")
-	public ResponseEntity<ApiRespDto<List<BusRouteStationRespDto>>> getRouteStations(
+	public ResponseEntity<List<BusRouteStationRespDto>> getRouteStations(
 		@RequestParam(value = "routeId", required = false) Long routeId,
 		@RequestParam(value = "stationId", required = false) Long stationId) {
 		List<BusRouteStationRespDto> routeStationList;
@@ -49,12 +49,6 @@ public class BusRouteStationController {
 		} else {
 			routeStationList = routeStationService.getRouteStations();
 		}
-		return ResponseEntity.ok(
-			ApiRespDto.<List<BusRouteStationRespDto>>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(routeStationList)
-				.build()
-		);
+		return ResponseEntity.ok(routeStationList);
 	}
 }

--- a/server/src/main/java/com/talkka/server/bus/controller/BusStationController.java
+++ b/server/src/main/java/com/talkka/server/bus/controller/BusStationController.java
@@ -10,9 +10,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.talkka.server.bus.dto.BusStationRespDto;
+import com.talkka.server.bus.exception.BusStationNotFoundException;
 import com.talkka.server.bus.service.BusStationService;
-import com.talkka.server.common.dto.ApiRespDto;
-import com.talkka.server.common.enums.StatusCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +22,7 @@ public class BusStationController {
 	private final BusStationService stationService;
 
 	@GetMapping("")
-	public ResponseEntity<ApiRespDto<List<BusStationRespDto>>> getStations(
+	public ResponseEntity<List<BusStationRespDto>> getStations(
 		@RequestParam(value = "search", required = false) String stationName) {
 		List<BusStationRespDto> stationList;
 
@@ -32,23 +31,18 @@ public class BusStationController {
 		} else {
 			stationList = stationService.getStations();
 		}
-		return ResponseEntity.ok(
-			ApiRespDto.<List<BusStationRespDto>>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(stationList)
-				.build()
-		);
+
+		return ResponseEntity.ok(stationList);
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiRespDto<BusStationRespDto>> getStationById(@PathVariable("id") Long stationId) {
-		return ResponseEntity.ok(
-			ApiRespDto.<BusStationRespDto>builder()
-				.statusCode(StatusCode.OK.getCode())
-				.message(StatusCode.OK.getMessage())
-				.data(stationService.getStationById(stationId))
-				.build()
-		);
+	public ResponseEntity<?> getStationById(@PathVariable("id") Long stationId) {
+		ResponseEntity<?> response;
+		try {
+			response = ResponseEntity.ok(stationService.getStationById(stationId));
+		} catch (BusStationNotFoundException exception) {
+			response = ResponseEntity.badRequest().body(exception.getMessage());
+		}
+		return response;
 	}
 }

--- a/server/src/main/java/com/talkka/server/bus/dao/BusRouteRepository.java
+++ b/server/src/main/java/com/talkka/server/bus/dao/BusRouteRepository.java
@@ -1,6 +1,7 @@
 package com.talkka.server.bus.dao;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BusRouteRepository extends JpaRepository<BusRouteEntity, Long> {
 	boolean existsByApiRouteId(String apiRouteId);
+
+	Optional<BusRouteEntity> findByApiRouteId(String apiRouteId);
 
 	List<BusRouteEntity> findAllByRouteNameStartingWithOrderByRouteNameAsc(String routeName);
 }

--- a/server/src/main/java/com/talkka/server/bus/dao/BusRouteRepository.java
+++ b/server/src/main/java/com/talkka/server/bus/dao/BusRouteRepository.java
@@ -1,18 +1,13 @@
 package com.talkka.server.bus.dao;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BusRouteRepository extends JpaRepository<BusRouteEntity, Long> {
-
 	boolean existsByApiRouteId(String apiRouteId);
 
-	Optional<BusRouteEntity> findByApiRouteId(String apiRouteId);
-
 	List<BusRouteEntity> findAllByRouteNameStartingWithOrderByRouteNameAsc(String routeName);
-
 }

--- a/server/src/main/java/com/talkka/server/bus/dao/BusStationRepository.java
+++ b/server/src/main/java/com/talkka/server/bus/dao/BusStationRepository.java
@@ -1,15 +1,12 @@
 package com.talkka.server.bus.dao;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BusStationRepository extends JpaRepository<BusStationEntity, Long> {
-	Optional<BusStationEntity> findByApiStationId(String apiStationId);
-
 	List<BusStationEntity> findByStationNameStartingWithOrderByStationNameAsc(String stationName);
 
 	boolean existsByApiStationId(String apiStationId);

--- a/server/src/main/java/com/talkka/server/bus/dao/BusStationRepository.java
+++ b/server/src/main/java/com/talkka/server/bus/dao/BusStationRepository.java
@@ -1,12 +1,15 @@
 package com.talkka.server.bus.dao;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BusStationRepository extends JpaRepository<BusStationEntity, Long> {
+	Optional<BusStationEntity> findByApiStationId(String apiStationId);
+
 	List<BusStationEntity> findByStationNameStartingWithOrderByStationNameAsc(String stationName);
 
 	boolean existsByApiStationId(String apiStationId);

--- a/server/src/main/java/com/talkka/server/bus/dto/BusRouteRespDto.java
+++ b/server/src/main/java/com/talkka/server/bus/dto/BusRouteRespDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 @Builder
 public record BusRouteRespDto(
 	Long routeId,
+	String apiRouteId,
 	String routeName,       // 노선 번호
 	BusRouteType routeTypeCd,        // 노선 유형 코드
 	String routeTypeName,   // 노선 유형명
@@ -31,6 +32,7 @@ public record BusRouteRespDto(
 	public static BusRouteRespDto of(BusRouteEntity busRouteEntity) {
 		return new BusRouteRespDto(
 			busRouteEntity.getId(),
+			busRouteEntity.getApiRouteId(),
 			busRouteEntity.getRouteName(),
 			busRouteEntity.getRouteTypeCd(),
 			busRouteEntity.getRouteTypeName(),

--- a/server/src/main/java/com/talkka/server/bus/dto/BusRouteStationCreateDto.java
+++ b/server/src/main/java/com/talkka/server/bus/dto/BusRouteStationCreateDto.java
@@ -8,8 +8,8 @@ import lombok.Builder;
 
 @Builder
 public record BusRouteStationCreateDto(
-	String apiRouteId,
-	String apiStationId,
+	Long routeId,
+	Long stationId,
 	Short stationSeq,
 	String stationName
 ) {

--- a/server/src/main/java/com/talkka/server/bus/dto/BusRouteStationRespDto.java
+++ b/server/src/main/java/com/talkka/server/bus/dto/BusRouteStationRespDto.java
@@ -9,21 +9,19 @@ import lombok.Builder;
 @Builder
 public record BusRouteStationRespDto(
 	Long busRouteStationId,
+	Long routeId,
+	Long stationId,
 	Short stationSeq,
 	String stationName,
-	Long routeId,
-	String routeName,
-	Long stationId,
 	LocalDateTime createdAt
 ) {
 	public static BusRouteStationRespDto of(BusRouteStationEntity busRouteStationEntity) {
 		return new BusRouteStationRespDto(
 			busRouteStationEntity.getId(),
+			busRouteStationEntity.getRoute().getId(),
+			busRouteStationEntity.getStation().getId(),
 			busRouteStationEntity.getStationSeq(),
 			busRouteStationEntity.getStation().getStationName(),
-			busRouteStationEntity.getRoute().getId(),
-			busRouteStationEntity.getRoute().getRouteName(),
-			busRouteStationEntity.getStation().getId(),
 			busRouteStationEntity.getCreatedAt()
 		);
 	}

--- a/server/src/main/java/com/talkka/server/bus/dto/BusStationRespDto.java
+++ b/server/src/main/java/com/talkka/server/bus/dto/BusStationRespDto.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 @Builder
 public record BusStationRespDto(
 	Long stationId,
+	String apiStationId,
 	String stationName,
 	String regionName,
 	DistrictCode districtCd,
@@ -25,6 +26,7 @@ public record BusStationRespDto(
 	public static BusStationRespDto of(BusStationEntity busStationEntity) {
 		return new BusStationRespDto(
 			busStationEntity.getId(),
+			busStationEntity.getApiStationId(),
 			busStationEntity.getStationName(),
 			busStationEntity.getRegionName(),
 			busStationEntity.getDistrictCd(),

--- a/server/src/main/java/com/talkka/server/bus/enums/EndBus.java
+++ b/server/src/main/java/com/talkka/server/bus/enums/EndBus.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public enum EndBus implements EnumCodeInterface {
 	// "0 = RUNNING" or "1 = END"
-	RUNNING("1"), END("0");
+	RUNNING("0"), END("1");
 
 	private final String code;
 

--- a/server/src/main/java/com/talkka/server/bus/exception/BusRouteNotFoundException.java
+++ b/server/src/main/java/com/talkka/server/bus/exception/BusRouteNotFoundException.java
@@ -1,0 +1,9 @@
+package com.talkka.server.bus.exception;
+
+public class BusRouteNotFoundException extends RuntimeException {
+	private static final String MESSAGE = "존재하지 않는 노선입니다. routeId: ";
+
+	public BusRouteNotFoundException(Long routeId) {
+		super(MESSAGE + routeId);
+	}
+}

--- a/server/src/main/java/com/talkka/server/bus/exception/BusRouteStationNotFoundException.java
+++ b/server/src/main/java/com/talkka/server/bus/exception/BusRouteStationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.talkka.server.bus.exception;
+
+public class BusRouteStationNotFoundException extends RuntimeException {
+	private static final String MESSAGE = "존재하지 않는 경유 정류장입니다. busRouteStationId: ";
+
+	public BusRouteStationNotFoundException(Long busRouteStationId) {
+		super(MESSAGE + busRouteStationId);
+	}
+}

--- a/server/src/main/java/com/talkka/server/bus/exception/BusStationAlreadyExistsException.java
+++ b/server/src/main/java/com/talkka/server/bus/exception/BusStationAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.talkka.server.bus.exception;
+
+public class BusStationAlreadyExistsException extends RuntimeException {
+	private static final String MESSAGE = "이미 존재하는 정거장입니다. apiStationId: ";
+
+	public BusStationAlreadyExistsException(String apiStationId) {
+		super(MESSAGE + apiStationId);
+	}
+}

--- a/server/src/main/java/com/talkka/server/bus/exception/BusStationNotFoundException.java
+++ b/server/src/main/java/com/talkka/server/bus/exception/BusStationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.talkka.server.bus.exception;
+
+public class BusStationNotFoundException extends RuntimeException {
+	private static final String MESSAGE = "존재하지 않는 정거장입니다. stationId: ";
+
+	public BusStationNotFoundException(Long stationId) {
+		super(MESSAGE + stationId);
+	}
+}

--- a/server/src/main/java/com/talkka/server/bus/exception/RouteAlreadyExistsException.java
+++ b/server/src/main/java/com/talkka/server/bus/exception/RouteAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.talkka.server.bus.exception;
+
+public class RouteAlreadyExistsException extends RuntimeException {
+	private static final String MESSAGE = "이미 존재하는 노선입니다. apiRouteId: ";
+
+	public RouteAlreadyExistsException(String apiRouteId) {
+		super(MESSAGE + apiRouteId);
+	}
+}

--- a/server/src/main/java/com/talkka/server/bus/service/BusRouteService.java
+++ b/server/src/main/java/com/talkka/server/bus/service/BusRouteService.java
@@ -8,7 +8,8 @@ import com.talkka.server.bus.dao.BusRouteEntity;
 import com.talkka.server.bus.dao.BusRouteRepository;
 import com.talkka.server.bus.dto.BusRouteCreateDto;
 import com.talkka.server.bus.dto.BusRouteRespDto;
-import com.talkka.server.common.exception.http.BadRequestException;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.RouteAlreadyExistsException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +18,9 @@ import lombok.RequiredArgsConstructor;
 public class BusRouteService {
 	private final BusRouteRepository busRouteRepository;
 
-	public BusRouteRespDto getRouteById(Long routeId) {
+	public BusRouteRespDto getRouteById(Long routeId) throws BusRouteNotFoundException {
 		BusRouteEntity busRouteEntity = busRouteRepository.findById(routeId)
-			.orElseThrow(() -> new BadRequestException("존재하지 않는 노선입니다."));
+			.orElseThrow(() -> new BusRouteNotFoundException(routeId));
 		return BusRouteRespDto.of(busRouteEntity);
 	}
 
@@ -35,10 +36,14 @@ public class BusRouteService {
 			.toList();
 	}
 
-	public BusRouteRespDto createRoute(BusRouteCreateDto busRouteCreateDto) {
-		if (!busRouteRepository.existsByApiRouteId(busRouteCreateDto.apiRouteId())) {
-			throw new BadRequestException("이미 등록된 버스 노선입니다.");
+	// TODO 아직 컨트롤러 없음, 관리자만 가능한 로직 필요
+	public BusRouteRespDto createRoute(BusRouteCreateDto busRouteCreateDto)
+		throws RouteAlreadyExistsException {
+		String apiRouteId = busRouteCreateDto.apiRouteId();
+		if (!busRouteRepository.existsByApiRouteId(apiRouteId)) {
+			throw new RouteAlreadyExistsException(apiRouteId);
 		}
+
 		return BusRouteRespDto.of(busRouteRepository.save(busRouteCreateDto.toEntity()));
 	}
 

--- a/server/src/main/java/com/talkka/server/bus/service/BusRouteStationService.java
+++ b/server/src/main/java/com/talkka/server/bus/service/BusRouteStationService.java
@@ -12,7 +12,9 @@ import com.talkka.server.bus.dao.BusStationEntity;
 import com.talkka.server.bus.dao.BusStationRepository;
 import com.talkka.server.bus.dto.BusRouteStationCreateDto;
 import com.talkka.server.bus.dto.BusRouteStationRespDto;
-import com.talkka.server.common.exception.http.BadRequestException;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.BusRouteStationNotFoundException;
+import com.talkka.server.bus.exception.BusStationNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,19 +26,25 @@ public class BusRouteStationService {
 	private final BusStationRepository stationRepository;
 	private final BusRouteStationRepository routeStationRepository;
 
-	public BusRouteStationRespDto createRouteStation(BusRouteStationCreateDto busRouteStationCreateDto) {
-		BusRouteEntity routeEntity = routeRepository.findByApiRouteId(busRouteStationCreateDto.apiRouteId())
-			.orElseThrow(() -> new BadRequestException("존재하지 않는 노선입니다."));
-		BusStationEntity stationEntity = stationRepository.findByApiStationId(
-				busRouteStationCreateDto.apiStationId())
-			.orElseThrow(() -> new BadRequestException("존재하지 않는 정류장입니다."));
+	// TODO controller에 추가 로직 없음, 추후 관리자가 추가할 수 있도록 추가 필요
+	public BusRouteStationRespDto createRouteStation(BusRouteStationCreateDto busRouteStationCreateDto)
+		throws BusRouteNotFoundException, BusStationNotFoundException {
+		Long routeId = busRouteStationCreateDto.routeId();
+		Long stationId = busRouteStationCreateDto.stationId();
+
+		BusRouteEntity routeEntity = routeRepository.findById(routeId)
+			.orElseThrow(() -> new BusRouteNotFoundException(routeId));
+		BusStationEntity stationEntity = stationRepository.findById(stationId)
+			.orElseThrow(() -> new BusStationNotFoundException(stationId));
+
 		BusRouteStationEntity busRouteStationEntity = busRouteStationCreateDto.toEntity(routeEntity, stationEntity);
 		return BusRouteStationRespDto.of(routeStationRepository.save(busRouteStationEntity));
 	}
 
-	public BusRouteStationRespDto getRouteStationById(Long id) {
+	public BusRouteStationRespDto getRouteStationById(Long id)
+		throws BusRouteStationNotFoundException {
 		BusRouteStationEntity busRouteStationEntity = routeStationRepository.findById(id)
-			.orElseThrow(() -> new BadRequestException("존재하지 않는 노선정류장입니다."));
+			.orElseThrow(() -> new BusRouteStationNotFoundException(id));
 		return BusRouteStationRespDto.of(busRouteStationEntity);
 	}
 

--- a/server/src/main/java/com/talkka/server/bus/service/BusStationService.java
+++ b/server/src/main/java/com/talkka/server/bus/service/BusStationService.java
@@ -8,7 +8,8 @@ import com.talkka.server.bus.dao.BusStationEntity;
 import com.talkka.server.bus.dao.BusStationRepository;
 import com.talkka.server.bus.dto.BusStationCreateDto;
 import com.talkka.server.bus.dto.BusStationRespDto;
-import com.talkka.server.common.exception.http.BadRequestException;
+import com.talkka.server.bus.exception.BusStationAlreadyExistsException;
+import com.talkka.server.bus.exception.BusStationNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +18,9 @@ import lombok.RequiredArgsConstructor;
 public class BusStationService {
 	private final BusStationRepository busStationRepository;
 
-	public BusStationRespDto getStationById(Long stationId) {
+	public BusStationRespDto getStationById(Long stationId) throws BusStationNotFoundException {
 		BusStationEntity busStationEntity = busStationRepository.findById(stationId)
-			.orElseThrow(() -> new BadRequestException("존재하지 않는 정거장입니다."));
+			.orElseThrow(() -> new BusStationNotFoundException(stationId));
 		return BusStationRespDto.of(busStationEntity);
 	}
 
@@ -35,10 +36,14 @@ public class BusStationService {
 			.toList();
 	}
 
-	public BusStationRespDto createStation(BusStationCreateDto busStationCreateDto) {
-		if (busStationRepository.existsByApiStationId(busStationCreateDto.apiStationId())) {
-			throw new BadRequestException("이미 등록된 정거장입니다.");
+	// TODO 아직 controller 없음
+	public BusStationRespDto createStation(BusStationCreateDto busStationCreateDto)
+		throws BusStationAlreadyExistsException {
+		String apiStationId = busStationCreateDto.apiStationId();
+		if (busStationRepository.existsByApiStationId(apiStationId)) {
+			throw new BusStationAlreadyExistsException(apiStationId);
 		}
+
 		return BusStationRespDto.of(busStationRepository.save(busStationCreateDto.toEntity()));
 	}
 }

--- a/server/src/main/java/com/talkka/server/review/controller/BusReviewController.java
+++ b/server/src/main/java/com/talkka/server/review/controller/BusReviewController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.BusStationNotFoundException;
 import com.talkka.server.common.exception.InvalidTypeException;
 import com.talkka.server.common.exception.enums.InvalidTimeSlotEnumException;
 import com.talkka.server.oauth.domain.OAuth2UserInfo;
@@ -22,8 +24,6 @@ import com.talkka.server.review.dto.BusReviewDto;
 import com.talkka.server.review.dto.BusReviewReqDto;
 import com.talkka.server.review.dto.BusReviewRespDto;
 import com.talkka.server.review.exception.BusReviewNotFoundException;
-import com.talkka.server.review.exception.BusRouteNotFoundException;
-import com.talkka.server.review.exception.BusStationNotFoundException;
 import com.talkka.server.review.exception.ContentAccessException;
 import com.talkka.server.review.exception.UserNotFoundException;
 import com.talkka.server.review.service.BusReviewService;

--- a/server/src/main/java/com/talkka/server/review/exception/BusRouteNotFoundException.java
+++ b/server/src/main/java/com/talkka/server/review/exception/BusRouteNotFoundException.java
@@ -1,9 +1,0 @@
-package com.talkka.server.review.exception;
-
-public class BusRouteNotFoundException extends RuntimeException {
-	private static final String MESSAGE = "존재하지 않는 노선입니다.";
-
-	public BusRouteNotFoundException() {
-		super(MESSAGE);
-	}
-}

--- a/server/src/main/java/com/talkka/server/review/exception/BusStationNotFoundException.java
+++ b/server/src/main/java/com/talkka/server/review/exception/BusStationNotFoundException.java
@@ -1,9 +1,0 @@
-package com.talkka.server.review.exception;
-
-public class BusStationNotFoundException extends RuntimeException {
-	private static final String MESSAGE = "존재하지 않는 정거장입니다.";
-
-	public BusStationNotFoundException() {
-		super(MESSAGE);
-	}
-}

--- a/server/src/main/java/com/talkka/server/review/service/BusReviewService.java
+++ b/server/src/main/java/com/talkka/server/review/service/BusReviewService.java
@@ -9,6 +9,9 @@ import com.talkka.server.bus.dao.BusRouteEntity;
 import com.talkka.server.bus.dao.BusRouteRepository;
 import com.talkka.server.bus.dao.BusRouteStationEntity;
 import com.talkka.server.bus.dao.BusRouteStationRepository;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.BusRouteStationNotFoundException;
+import com.talkka.server.bus.exception.BusStationNotFoundException;
 import com.talkka.server.common.enums.TimeSlot;
 import com.talkka.server.common.exception.enums.InvalidTimeSlotEnumException;
 import com.talkka.server.common.validator.ContentAccessValidator;
@@ -17,8 +20,6 @@ import com.talkka.server.review.dao.BusReviewRepository;
 import com.talkka.server.review.dto.BusReviewDto;
 import com.talkka.server.review.dto.BusReviewRespDto;
 import com.talkka.server.review.exception.BusReviewNotFoundException;
-import com.talkka.server.review.exception.BusRouteNotFoundException;
-import com.talkka.server.review.exception.BusStationNotFoundException;
 import com.talkka.server.review.exception.ContentAccessException;
 import com.talkka.server.review.exception.UserNotFoundException;
 import com.talkka.server.user.dao.UserEntity;
@@ -77,12 +78,15 @@ public class BusReviewService {
 	public BusReviewRespDto createBusReview(BusReviewDto busReviewDto)
 		throws UserNotFoundException, BusStationNotFoundException, BusRouteNotFoundException {
 		Long userId = busReviewDto.userId();
+		Long busRouteStationId = busReviewDto.busRouteStationId();
+		Long routeId = busReviewDto.routeId();
+
 		UserEntity user = userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
-		BusRouteStationEntity station = busRouteStationRepository.findById(busReviewDto.busRouteStationId())
-			.orElseThrow(BusStationNotFoundException::new);
-		BusRouteEntity route = busRouteRepository.findById(busReviewDto.routeId())
-			.orElseThrow(BusRouteNotFoundException::new);
+		BusRouteStationEntity station = busRouteStationRepository.findById(busRouteStationId)
+			.orElseThrow(() -> new BusRouteStationNotFoundException(busRouteStationId));
+		BusRouteEntity route = busRouteRepository.findById(routeId)
+			.orElseThrow(() -> new BusRouteNotFoundException(routeId));
 
 		BusReviewEntity entity = busReviewDto.toEntity(user, station, route);
 		BusReviewEntity savedReview = busReviewRepository.save(entity);

--- a/server/src/test/java/com/talkka/server/bus/BusTestFactory.java
+++ b/server/src/test/java/com/talkka/server/bus/BusTestFactory.java
@@ -18,37 +18,10 @@ import com.talkka.server.bus.enums.TurnStation;
 
 public class BusTestFactory {
 
-	public static BusRouteEntity getBusRouteEntity(Long id) {
+	public static BusRouteEntity getBusRouteEntity(Long routeId) {
 		return BusRouteEntity.builder()
-			.id(id)
-			.apiRouteId("BRT" + id)
-			.routeName("7800" + id)
-			.routeTypeCd(BusRouteType.DIRECT_SEAT_CITY_BUS)
-			.routeTypeName(BusRouteType.DIRECT_SEAT_CITY_BUS.getName())
-			.companyId("COMP123")
-			.companyName("수형운수")
-			.companyTel("02-123-4567")
-			.districtCd(DistrictCode.DONGDUCHEON)
-			.upFirstTime("05:30")
-			.upLastTime("23:00")
-			.downFirstTime("06:00")
-			.downLastTime("00:35")
-			.startMobileNo("101")
-			.startStationId(1001L)
-			.startStationName("기점 정류소")
-			.endStationId(2002L)
-			.endMobileNo("202")
-			.endStationName("종점 정류소")
-			.regionName("서울")
-			.peekAlloc(15)
-			.nPeekAlloc(25)
-			.build();
-	}
-
-	public static BusRouteCreateDto getBusRouteCreateDto(Long id) {
-
-		return BusRouteCreateDto.builder()
-			.apiRouteId("BRT" + id)
+			.id(routeId)
+			.apiRouteId("apiRouteId")
 			.routeName("7800")
 			.routeTypeCd(BusRouteType.DIRECT_SEAT_CITY_BUS)
 			.routeTypeName(BusRouteType.DIRECT_SEAT_CITY_BUS.getName())
@@ -72,10 +45,38 @@ public class BusTestFactory {
 			.build();
 	}
 
-	public static BusRouteRespDto getBusRouteRespDto(Long id) {
+	public static BusRouteCreateDto getBusRouteCreateDto(String apiRouteId) {
+
+		return BusRouteCreateDto.builder()
+			.apiRouteId("apiRouteId")
+			.routeName("7800")
+			.routeTypeCd(BusRouteType.DIRECT_SEAT_CITY_BUS)
+			.routeTypeName(BusRouteType.DIRECT_SEAT_CITY_BUS.getName())
+			.companyId("COMP123")
+			.companyName("수형운수")
+			.companyTel("02-123-4567")
+			.districtCd(DistrictCode.DONGDUCHEON)
+			.upFirstTime("05:30")
+			.upLastTime("23:00")
+			.downFirstTime("06:00")
+			.downLastTime("00:35")
+			.startMobileNo("101")
+			.startStationId(1001L)
+			.startStationName("기점 정류소")
+			.endStationId(2002L)
+			.endMobileNo("202")
+			.endStationName("종점 정류소")
+			.regionName("서울")
+			.peekAlloc(15)
+			.nPeekAlloc(25)
+			.build();
+	}
+
+	public static BusRouteRespDto getBusRouteRespDto(Long routeId) {
 		return BusRouteRespDto.builder()
-			.routeId(id)
-			.routeName("7800" + id)
+			.routeId(routeId)
+			.apiRouteId("apiRouteId")
+			.routeName("7800")
 			.routeTypeCd(BusRouteType.DIRECT_SEAT_CITY_BUS)
 			.routeTypeName(BusRouteType.DIRECT_SEAT_CITY_BUS.getName())
 			.districtCd(DistrictCode.DONGDUCHEON)
@@ -95,11 +96,11 @@ public class BusTestFactory {
 			.build();
 	}
 
-	public static BusStationEntity getBusStationEntity(Long id) {
+	public static BusStationEntity getBusStationEntity(Long stationId) {
 		return BusStationEntity.builder()
-			.id(id)
-			.apiStationId("BST" + id)
-			.stationName("정거장" + id)
+			.id(stationId)
+			.apiStationId("apiStationId")
+			.stationName("7800 정류장")
 			.regionName("서울")
 			.districtCd(DistrictCode.DONGDUCHEON)
 			.centerYn(CenterStation.CENTER_STATION)
@@ -109,10 +110,10 @@ public class BusTestFactory {
 			.build();
 	}
 
-	public static BusStationCreateDto getBusStationCreateDto(Long id) {
+	public static BusStationCreateDto getBusStationCreateDto(String apiStationId) {
 		return BusStationCreateDto.builder()
-			.apiStationId("BST" + id)
-			.stationName("정거장" + id)
+			.apiStationId(apiStationId)
+			.stationName("7800 정류장")
 			.regionName("서울")
 			.districtCd(DistrictCode.DONGDUCHEON)
 			.centerYn(CenterStation.CENTER_STATION)
@@ -122,10 +123,11 @@ public class BusTestFactory {
 			.build();
 	}
 
-	public static BusStationRespDto getBusStationRespDto(Long id) {
+	public static BusStationRespDto getBusStationRespDto(Long stationId) {
 		return BusStationRespDto.builder()
-			.stationId(id)
-			.stationName("정거장" + id)
+			.stationId(stationId)
+			.apiStationId("apiStationId")
+			.stationName("7800 정류장")
 			.regionName("서울")
 			.districtCd(DistrictCode.DONGDUCHEON)
 			.centerYn(CenterStation.CENTER_STATION)
@@ -135,35 +137,35 @@ public class BusTestFactory {
 			.build();
 	}
 
-	public static BusRouteStationEntity getBusRouteStationEntity(Long id, BusRouteEntity routeEntity,
-		BusStationEntity stationEntity) {
+	public static BusRouteStationEntity getBusRouteStationEntity(
+		Long routeStationId, BusRouteEntity routeEntity, BusStationEntity stationEntity
+	) {
 		return BusRouteStationEntity.builder()
-			.id(id)
+			.id(routeStationId)
 			.route(routeEntity)
 			.station(stationEntity)
-			.stationName("정거장" + id)
-			.stationSeq(Short.valueOf(String.valueOf(id)))
+			.stationName("7800 정류장")
+			.stationSeq(Short.valueOf(String.valueOf(routeStationId)))
 			.build();
 	}
 
-	public static BusRouteStationCreateDto getBusRouteStationCreateDto(Long id) {
+	public static BusRouteStationCreateDto getBusRouteStationCreateDto(Long routeId, Long stationId) {
 		return BusRouteStationCreateDto.builder()
-			.apiRouteId("BRT" + id)
-			.apiStationId("BST" + id)
-			.stationName("정거장" + id)
-			.stationSeq(Short.valueOf(String.valueOf(id)))
+			.routeId(routeId)
+			.stationId(stationId)
+			.stationName("7800 정류장")
+			.stationSeq(Short.valueOf(String.valueOf(routeId)))
 			.build();
 	}
 
-	public static BusRouteStationRespDto getBusRouteStationRespDto(Long id, BusRouteRespDto routeRespDto,
-		BusStationRespDto stationRespDto) {
+	public static BusRouteStationRespDto getBusRouteStationRespDto(
+		Long routeStationId, BusRouteRespDto routeRespDto, BusStationRespDto stationRespDto) {
 		return BusRouteStationRespDto.builder()
-			.busRouteStationId(id)
+			.busRouteStationId(routeStationId)
 			.stationId(stationRespDto.stationId())
-			.stationName("정거장" + stationRespDto.stationId())
-			.stationSeq(Short.valueOf(String.valueOf(id)))
+			.stationName(stationRespDto.stationName())
+			.stationSeq(Short.valueOf(String.valueOf(routeStationId)))
 			.routeId(routeRespDto.routeId())
-			.routeName(routeRespDto.routeName())
 			.build();
 	}
 

--- a/server/src/test/java/com/talkka/server/bus/controller/BusRouteControllerTest.java
+++ b/server/src/test/java/com/talkka/server/bus/controller/BusRouteControllerTest.java
@@ -15,10 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
-import com.talkka.server.bus.dto.BusRouteRespDto;
 import com.talkka.server.bus.service.BusRouteService;
-import com.talkka.server.common.dto.ApiRespDto;
-import com.talkka.server.common.enums.StatusCode;
 
 @ExtendWith(MockitoExtension.class)
 public class BusRouteControllerTest {
@@ -36,13 +33,7 @@ public class BusRouteControllerTest {
 		void routeId를_받아_해당_아이디의_노선을_조회한다() {
 			// given
 			Long id = 1L;
-			var expected = ResponseEntity.ok(
-				ApiRespDto.<BusRouteRespDto>builder()
-					.statusCode(StatusCode.OK.getCode())
-					.message(StatusCode.OK.getMessage())
-					.data(getBusRouteRespDto(id))
-					.build()
-			);
+			var expected = ResponseEntity.ok(getBusRouteRespDto(id));
 			given(routeService.getRouteById(anyLong())).willReturn(getBusRouteRespDto(id));
 			// when
 			var result = routeController.getRouteById(id);
@@ -62,17 +53,11 @@ public class BusRouteControllerTest {
 			Long id2 = 2L;
 			Long id3 = 3L;
 			var expected = ResponseEntity.ok(
-				ApiRespDto.<List<BusRouteRespDto>>builder()
-					.statusCode(StatusCode.OK.getCode())
-					.message(StatusCode.OK.getMessage())
-					.data(
-						List.of(
-							getBusRouteRespDto(id1),
-							getBusRouteRespDto(id2),
-							getBusRouteRespDto(id3)
-						)
-					)
-					.build()
+				List.of(
+					getBusRouteRespDto(id1),
+					getBusRouteRespDto(id2),
+					getBusRouteRespDto(id3)
+				)
 			);
 			given(routeService.getRoutesByRouteName(anyString())).willReturn(
 				List.of(

--- a/server/src/test/java/com/talkka/server/bus/service/BusRouteServiceTest.java
+++ b/server/src/test/java/com/talkka/server/bus/service/BusRouteServiceTest.java
@@ -19,7 +19,8 @@ import com.talkka.server.bus.dao.BusRouteEntity;
 import com.talkka.server.bus.dao.BusRouteRepository;
 import com.talkka.server.bus.dto.BusRouteCreateDto;
 import com.talkka.server.bus.dto.BusRouteRespDto;
-import com.talkka.server.common.exception.http.BadRequestException;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.RouteAlreadyExistsException;
 
 @ExtendWith(MockitoExtension.class)
 public class BusRouteServiceTest {
@@ -30,15 +31,18 @@ public class BusRouteServiceTest {
 	@Mock
 	private BusRouteRepository busRouteRepository;
 
+	private final Long routeId = 1L;
+	private final String apiRouteId = "apiRouteId";
+
 	@Nested
 	@DisplayName("createRoute method")
 	public class CreateRouteTest {
 		@Test
 		void 버스_노선을_생성한다() {
 			// given
-			BusRouteCreateDto busRouteCreateDto = getBusRouteCreateDto(1L);
-			BusRouteRespDto busRouteRespDto = getBusRouteRespDto(1L);
-			BusRouteEntity busRouteEntity = getBusRouteEntity(1L);
+			BusRouteCreateDto busRouteCreateDto = getBusRouteCreateDto(apiRouteId);
+			BusRouteRespDto busRouteRespDto = getBusRouteRespDto(routeId);
+			BusRouteEntity busRouteEntity = getBusRouteEntity(routeId);
 			given(busRouteRepository.save(any(BusRouteEntity.class))).willReturn(busRouteEntity);
 			given(busRouteRepository.existsByApiRouteId(any(String.class))).willReturn(true);
 			// when
@@ -50,14 +54,13 @@ public class BusRouteServiceTest {
 		@Test
 		void 존재하는_버스_노선일_경우_Exception을_발생시킨다() {
 			// given
-			BusRouteCreateDto reqDto = getBusRouteCreateDto(1L);
+			BusRouteCreateDto reqDto = getBusRouteCreateDto(apiRouteId);
 			given(busRouteRepository.existsByApiRouteId(any(String.class))).willReturn(false);
 			// when
 			// then
-			assertThatThrownBy(
-				() -> busRouteService.createRoute(reqDto)
-			).isInstanceOf(BadRequestException.class)
-				.hasMessage("이미 등록된 버스 노선입니다.");
+			assertThatThrownBy(() -> busRouteService.createRoute(reqDto))
+				.isInstanceOf(RouteAlreadyExistsException.class)
+				.hasMessage("이미 존재하는 노선입니다. apiRouteId: " + apiRouteId);
 		}
 	}
 
@@ -67,7 +70,6 @@ public class BusRouteServiceTest {
 		@Test
 		void ID를_기반으로_버스_노선을_요청하면_레포지토리를_통해_결과를_DTO로_반환한다() {
 			// given
-			Long routeId = 1L;
 			BusRouteEntity foundEntity = getBusRouteEntity(routeId);
 			given(busRouteRepository.findById(anyLong())).willReturn(Optional.of(foundEntity));
 			// when
@@ -80,14 +82,12 @@ public class BusRouteServiceTest {
 		@Test
 		void ID가_존재하지_않으면_Exception을_throw한다() {
 			// given
-			Class<?> exceptionClass = BadRequestException.class;
 			given(busRouteRepository.findById(anyLong())).willReturn(Optional.empty());
 			// when
 			// then
-			assertThatThrownBy(
-				() -> busRouteService.getRouteById(1L)
-			).isInstanceOf(exceptionClass)
-				.hasMessage("존재하지 않는 노선입니다.");
+			assertThatThrownBy(() -> busRouteService.getRouteById(routeId))
+				.isInstanceOf(BusRouteNotFoundException.class)
+				.hasMessage("존재하지 않는 노선입니다. routeId: " + routeId);
 			verify(busRouteRepository, times(1)).findById(anyLong());
 		}
 	}
@@ -95,20 +95,16 @@ public class BusRouteServiceTest {
 	@Nested
 	@DisplayName("getRoutesByRouteName method")
 	public class GetRoutesByRouteNameTest {
-
 		@Test
 		void 버스노선이름을_요청으로_받아_repository에서_조회하고_해당_이름으로_시작하는_노선들을_리스트로_반환한다() {
-
 			// given
 			String routeName = "7800";
 			var entityList = List.of(getBusRouteEntity(1L), getBusRouteEntity(2L));
 			var expectedList = List.of(getBusRouteRespDto(1L), getBusRouteRespDto(2L));
-			given(busRouteRepository.findAllByRouteNameStartingWithOrderByRouteNameAsc(any(String.class))).willReturn(
-				entityList);
-
+			given(busRouteRepository.findAllByRouteNameStartingWithOrderByRouteNameAsc(any(String.class)))
+				.willReturn(entityList);
 			// when
 			var resultList = busRouteService.getRoutesByRouteName(routeName);
-
 			// then
 			verify(busRouteRepository, times(1)).findAllByRouteNameStartingWithOrderByRouteNameAsc(anyString());
 			assertThat(resultList).containsAll(expectedList);

--- a/server/src/test/java/com/talkka/server/review/service/BusReviewServiceTest.java
+++ b/server/src/test/java/com/talkka/server/review/service/BusReviewServiceTest.java
@@ -19,6 +19,8 @@ import com.talkka.server.bus.dao.BusRouteEntity;
 import com.talkka.server.bus.dao.BusRouteRepository;
 import com.talkka.server.bus.dao.BusRouteStationEntity;
 import com.talkka.server.bus.dao.BusRouteStationRepository;
+import com.talkka.server.bus.exception.BusRouteNotFoundException;
+import com.talkka.server.bus.exception.BusRouteStationNotFoundException;
 import com.talkka.server.common.enums.TimeSlot;
 import com.talkka.server.common.exception.enums.InvalidTimeSlotEnumException;
 import com.talkka.server.common.validator.ContentAccessValidator;
@@ -27,8 +29,6 @@ import com.talkka.server.review.dao.BusReviewRepository;
 import com.talkka.server.review.dto.BusReviewDto;
 import com.talkka.server.review.dto.BusReviewRespDto;
 import com.talkka.server.review.exception.BusReviewNotFoundException;
-import com.talkka.server.review.exception.BusRouteNotFoundException;
-import com.talkka.server.review.exception.BusStationNotFoundException;
 import com.talkka.server.review.exception.ContentAccessException;
 import com.talkka.server.review.exception.UserNotFoundException;
 import com.talkka.server.review.vo.Rating;
@@ -217,7 +217,7 @@ public class BusReviewServiceTest {
 		}
 
 		@Test
-		@DisplayName("리뷰 생성시, BusRouteStationEntity가 없을 경우 BusStationNotFoundException을 발생시킨다.")
+		@DisplayName("리뷰 생성시, BusRouteStationEntity가 없을 경우 BusRouteStationNotFoundException을 발생시킨다.")
 		void testBusStationNotFoundException() {
 			// given
 			given(userRepository.findById(anyLong())).willReturn(Optional.of(getUserFixture(userId)));
@@ -225,7 +225,7 @@ public class BusReviewServiceTest {
 			// when
 			// then
 			assertThatThrownBy(() -> busReviewService.createBusReview(busReviewDto))
-				.isInstanceOf(BusStationNotFoundException.class);
+				.isInstanceOf(BusRouteStationNotFoundException.class);
 		}
 
 		@Test


### PR DESCRIPTION
## 작업내용
- 버스 컨트롤러, 서비스 리팩토링
- 경류 정류장 테이블 저장 시 apiXXXId로 넘기던 것 XXXId로 변경
  - 서비스 내에서 사용하는 정보는 apiXXXId가 아닌 XXXId
  - apiXXXId의 경우는 공공 데이터에서 받아온 데이터
- ResponseDto에서 apiXXXId 필드 추가
  - 다른 서비스에서 필요한 데이터
- Exception 추가 및 패키지 변경
  - busReview에 있던 bus 도메인 exception을 bus 패키지 하위로 변경

Closes #91 