### PR TITLE
[FEAT] HTTP Request / Response 기본 logging

### DIFF
--- a/server/src/main/java/com/talkka/server/common/log/HttpLogMessage.java
+++ b/server/src/main/java/com/talkka/server/common/log/HttpLogMessage.java
@@ -7,9 +7,9 @@ import lombok.Builder;
 
 @Builder
 public record HttpLogMessage(String httpMethod, String requestUri, Integer httpStatus, String clientIp,
-							 Double elapsedTimeMs, String requestParam, String requestBody, String responseBody) {
+							 Long elapsedTimeMs, String requestParam, String requestBody, String responseBody) {
 	public static HttpLogMessage create(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response,
-		Double elapsedTimeMs) {
+		Long elapsedTimeMs) {
 		return HttpLogMessage.builder()
 			.httpMethod(request.getMethod())
 			.requestUri(request.getRequestURI())
@@ -26,7 +26,7 @@ public record HttpLogMessage(String httpMethod, String requestUri, Integer httpS
 		String format = """
 			HTTP REQUEST %s %s %s
 			| ClientIp: %s
-			| ElapsedTimeMs: %s
+			| ElapsedTimeMs: %sms
 			| RequestParam: %s
 			| RequestBody: %s
 			| ResponseBody: %s

--- a/server/src/main/java/com/talkka/server/common/log/HttpLogMessage.java
+++ b/server/src/main/java/com/talkka/server/common/log/HttpLogMessage.java
@@ -1,0 +1,39 @@
+package com.talkka.server.common.log;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import lombok.Builder;
+
+@Builder
+public record HttpLogMessage(String httpMethod, String requestUri, Integer httpStatus, String clientIp,
+							 Double elapsedTimeMs, String requestParam, String requestBody, String responseBody) {
+	public static HttpLogMessage create(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response,
+		Double elapsedTimeMs) {
+		return HttpLogMessage.builder()
+			.httpMethod(request.getMethod())
+			.requestUri(request.getRequestURI())
+			.httpStatus(response.getStatus())
+			.clientIp(request.getRemoteAddr())
+			.elapsedTimeMs(elapsedTimeMs)
+			.requestParam(request.getQueryString())
+			.requestBody(new String(request.getContentAsByteArray()))
+			.responseBody(new String(response.getContentAsByteArray()))
+			.build();
+	}
+
+	public String beatify() {
+		String format = """
+			HTTP REQUEST %s %s %s
+			| ClientIp: %s
+			| ElapsedTimeMs: %s
+			| RequestParam: %s
+			| RequestBody: %s
+			| ResponseBody: %s
+			""";
+
+		return String.format(format, httpMethod, requestUri, httpStatus, clientIp, elapsedTimeMs, requestParam,
+			requestBody, responseBody
+		);
+	}
+}

--- a/server/src/main/java/com/talkka/server/common/log/LoggingFilter.java
+++ b/server/src/main/java/com/talkka/server/common/log/LoggingFilter.java
@@ -32,7 +32,7 @@ public class LoggingFilter extends OncePerRequestFilter {
 
 		try {
 			var logMessage = HttpLogMessage.create(cachingRequestWrapper, cachingResponseWrapper,
-					(endTime - startTime) / 1000.0)
+					(endTime - startTime))
 				.beatify();
 			log.info(logMessage);
 			cachingResponseWrapper.copyBodyToResponse();

--- a/server/src/main/java/com/talkka/server/common/log/LoggingFilter.java
+++ b/server/src/main/java/com/talkka/server/common/log/LoggingFilter.java
@@ -1,0 +1,43 @@
+package com.talkka.server.common.log;
+
+import java.io.IOException;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LoggingFilter extends OncePerRequestFilter {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		var cachingRequestWrapper = new ContentCachingRequestWrapper(request);
+		var cachingResponseWrapper = new ContentCachingResponseWrapper(response);
+
+		var startTime = System.currentTimeMillis();
+		filterChain.doFilter(cachingRequestWrapper, cachingResponseWrapper);
+		var endTime = System.currentTimeMillis();
+
+		try {
+			var logMessage = HttpLogMessage.create(cachingRequestWrapper, cachingResponseWrapper,
+					(endTime - startTime) / 1000.0)
+				.beatify();
+			log.info(logMessage);
+			cachingResponseWrapper.copyBodyToResponse();
+		} catch (Exception exception) {
+			log.error("Logging 실패");
+		}
+	}
+}


### PR DESCRIPTION
## 결과 예시
![image](https://github.com/user-attachments/assets/15a49bf0-4b69-40a8-b45e-d1cd4edbad6d)

## 작업 내용
- Logging Filter 추가
  - OncePerRequestFilter 적용 (Filter 두번 타는 경우 방지)
  - 총 지연시간 ms 로 표현
  - Security 보다 먼저 거치도록 가장 Order 를 높게 잡음.

Closes #106