### PR TITLE
[REVERT] "[FEAT] Exception Handler 에서 Exception.class 에 대한 처리"

### DIFF
--- a/server/src/main/java/com/talkka/server/common/exception/handler/RestControllerAdvice.java
+++ b/server/src/main/java/com/talkka/server/common/exception/handler/RestControllerAdvice.java
@@ -31,12 +31,6 @@ public class RestControllerAdvice {
 		return new ResponseEntity<>(INTERNAL_SERVER_ERROR_MESSAGE, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<String> handleException(Exception exception) {
-		log.error("Exception: {}", exception.getMessage());
-		return new ResponseEntity<>(INTERNAL_SERVER_ERROR_MESSAGE, HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
 	@Deprecated
 	@ExceptionHandler(HttpBaseException.class)
 	public ResponseEntity<ApiRespDto<Void>> handleHttpException(HttpBaseException exception) {


### PR DESCRIPTION
## Revert 사유
- Exception handling 과정에서, 해당 시점에 catch 되지 말아야할 error (`@Secured` 에러와 같은 것들) 까지 catch 되어 처리되고 있음.

Reverts Kernel360/E2E2-TALKKA#105